### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,29 +2,29 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-mcp47FE			KEYWORD1
+mcp47FE	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin			KEYWORD2
-reset			KEYWORD2
-wake			KEYWORD2
-update			KEYWORD2
-analogWrite		KEYWORD2
-eepromWrite		KEYWORD2
-eepromReset		KEYWORD2
-setVref			KEYWORD2
-setGain			KEYWORD2
-setPowerDown		KEYWORD2
-getId			KEYWORD2
-getVref			KEYWORD2
-getGain			KEYWORD2
-getPowerDown		KEYWORD2
-getValue		KEYWORD2
-vdd			KEYWORD2
-getVout			KEYWORD2
-voutWrite		KEYWORD2
+begin	KEYWORD2
+reset	KEYWORD2
+wake	KEYWORD2
+update	KEYWORD2
+analogWrite	KEYWORD2
+eepromWrite	KEYWORD2
+eepromReset	KEYWORD2
+setVref	KEYWORD2
+setGain	KEYWORD2
+setPowerDown	KEYWORD2
+getId	KEYWORD2
+getVref	KEYWORD2
+getGain	KEYWORD2
+getPowerDown	KEYWORD2
+getValue	KEYWORD2
+vdd	KEYWORD2
+getVout	KEYWORD2
+voutWrite	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords